### PR TITLE
Enable the propagation of masks by `ObjID` and enter/exit frame values

### DIFF
--- a/SAM2_Tracking/create_video.py
+++ b/SAM2_Tracking/create_video.py
@@ -1,7 +1,8 @@
 from utils import read_config_yaml, write_output_video
 
 # Specify the path to the configuration YAML file
-yaml_file_path = "./test_configs.yaml"
+# yaml_file_path = "./test_configs.yaml"
+yaml_file_path = "/projects/brre2566/annotator_gui_configs/test_configs.yaml"
 
 # Read and load the configuration YAML
 configs = read_config_yaml(yaml_file_path)

--- a/SAM2_Tracking/create_video.py
+++ b/SAM2_Tracking/create_video.py
@@ -2,7 +2,7 @@ from utils import read_config_yaml, write_output_video
 
 # Specify the path to the configuration YAML file
 # yaml_file_path = "./test_configs.yaml"
-yaml_file_path = "/projects/brre2566/annotator_gui_configs/test_configs.yaml"
+yaml_file_path = "/projects/brre2566/annotator_gui_configs/GX137102_entex_configs.yaml"
 
 # Read and load the configuration YAML
 configs = read_config_yaml(yaml_file_path)

--- a/SAM2_Tracking/create_video.py
+++ b/SAM2_Tracking/create_video.py
@@ -1,8 +1,7 @@
 from utils import read_config_yaml, write_output_video
 
 # Specify the path to the configuration YAML file
-# yaml_file_path = "./test_configs.yaml"
-yaml_file_path = "/projects/brre2566/annotator_gui_configs/GX137102_entex_configs.yaml"
+yaml_file_path = "./template_configs.yaml"
 
 # Read and load the configuration YAML
 configs = read_config_yaml(yaml_file_path)

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -3,7 +3,8 @@ import torch
 import utils  
 
 # Specify the path to the configuration YAML file
-yaml_file_path = "./template_configs.yaml"
+# yaml_file_path = "./template_configs.yaml"
+yaml_file_path = "/projects/brre2566/annotator_gui_configs/test_configs.yaml"
 
 # Set device for PyTorch 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -13,9 +14,41 @@ segmenter = SAM2FishSegmenter(configs=yaml_file_path, device=device)
 segmenter.set_inference_state()
 
 # TODO: should we create a config file specifically for these? 
-annotations_filtered  = utils.filter_annotations(annotations_file=segmenter.configs["annotations_file"], 
-                                                 fps=segmenter.configs["fps"], SAM2_start=segmenter.configs["SAM2_start"])
+# annotations_filtered  = utils.filter_annotations(annotations_file=segmenter.configs["annotations_file"], 
+#                                                  fps=segmenter.configs["fps"], SAM2_start=segmenter.configs["SAM2_start"])
+import numpy as np 
+import pandas as pd 
+annotations_filtered = np.load(segmenter.configs["annotations_file"], allow_pickle=True)
+annotations_filtered = pd.DataFrame(list(annotations_filtered))
 
-segmenter.add_annotations(annotations=annotations_filtered)
+fish_frame_chunks, annotations_filtered = utils.get_frame_chunks_df(df=annotations_filtered)
 
-segmenter.run_propagation()
+# print(f"fish_frame_chunks: {fish_frame_chunks}")
+
+# Create list of keys corresponding to the Frame value 
+keys = [str(i) for i in range(len(segmenter.frame_paths))]
+
+# Initialize a dictionary with provided keys and set values as empty dictionaries
+frame_masks = {key: {} for key in keys}
+
+annotations = annotations_filtered
+for fish_label in fish_frame_chunks.index:
+
+    enter_frame = fish_frame_chunks.loc[fish_label]['EnterFrame']
+    exit_frame = fish_frame_chunks.loc[fish_label]['ExitFrame']
+    num_frames = exit_frame - enter_frame
+
+    # Get all of the annotations for the given fishLabel
+    annotation_fish = annotations.loc[fish_label]
+
+    # Get all annotations that have Frame values between enter_frame and exit_frame inclusive 
+    annotation_chunk = annotation_fish[(annotation_fish['Frame'] >= enter_frame) & (annotation_fish['Frame'] <= exit_frame)]
+
+    # Reset inference state for the new incoming annotations 
+    segmenter.predictor.reset_state(segmenter.inference_state)
+
+    # Add point annotations for provided annotation chunk 
+    segmenter.add_annotations(annotations=annotation_chunk)
+
+    # Run propagation on annotation chunk of frames
+    segmenter.run_propagation(start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -3,8 +3,7 @@ import torch
 import utils  
 
 # Specify the path to the configuration YAML file
-# yaml_file_path = "./template_configs.yaml"
-yaml_file_path = "/projects/brre2566/annotator_gui_configs/GX137102_entex_configs.yaml"
+yaml_file_path = "./template_configs.yaml"
 
 # Set device for PyTorch 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -23,14 +23,7 @@ annotations_filtered = pd.DataFrame(list(annotations_filtered))
 
 fish_frame_chunks, annotations_filtered = utils.get_frame_chunks_df(df=annotations_filtered)
 
-# print(f"fish_frame_chunks: {fish_frame_chunks}")
-
-# Create list of keys corresponding to the Frame value 
-keys = [str(i) for i in range(len(segmenter.frame_paths))]
-
-# Initialize a dictionary with provided keys and set values as empty dictionaries
-frame_masks = {key: {} for key in keys}
-
+frame_masks = {}
 annotations = annotations_filtered
 for fish_label in fish_frame_chunks.index:
 
@@ -51,4 +44,9 @@ for fish_label in fish_frame_chunks.index:
     segmenter.add_annotations(annotations=annotation_chunk)
 
     # Run propagation on annotation chunk of frames
-    segmenter.run_propagation(start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)
+    frame_masks += segmenter.run_propagation(start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)
+
+if segmenter.configs["save_masks"]: 
+    # Save frame_masks as pkl file 
+    with open(segmenter.configs["masks_dict_file"], "wb") as file:
+            pickle.dump(frame_masks, file)

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -11,42 +11,4 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 segmenter = SAM2FishSegmenter(configs=yaml_file_path, device=device)
 
-segmenter.set_inference_state()
-
-# TODO: should we create a config file specifically for these? 
-# annotations_filtered  = utils.filter_annotations(annotations_file=segmenter.configs["annotations_file"], 
-#                                                  fps=segmenter.configs["fps"], SAM2_start=segmenter.configs["SAM2_start"])
-import numpy as np 
-import pandas as pd 
-annotations_filtered = np.load(segmenter.configs["annotations_file"], allow_pickle=True)
-annotations_filtered = pd.DataFrame(list(annotations_filtered))
-
-fish_frame_chunks, annotations_filtered = utils.get_frame_chunks_df(df=annotations_filtered)
-
-frame_masks = {}
-annotations = annotations_filtered
-for fish_label in fish_frame_chunks.index:
-
-    enter_frame = fish_frame_chunks.loc[fish_label]['EnterFrame']
-    exit_frame = fish_frame_chunks.loc[fish_label]['ExitFrame']
-    num_frames = exit_frame - enter_frame
-
-    # Get all of the annotations for the given fishLabel
-    annotation_fish = annotations.loc[fish_label]
-
-    # Get all annotations that have Frame values between enter_frame and exit_frame inclusive 
-    annotation_chunk = annotation_fish[(annotation_fish['Frame'] >= enter_frame) & (annotation_fish['Frame'] <= exit_frame)]
-
-    # Reset inference state for the new incoming annotations 
-    segmenter.predictor.reset_state(segmenter.inference_state)
-
-    # Add point annotations for provided annotation chunk 
-    segmenter.add_annotations(annotations=annotation_chunk)
-
-    # Run propagation on annotation chunk of frames
-    frame_masks += segmenter.get_masks(start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)
-
-if segmenter.configs["save_masks"]: 
-    # Save frame_masks as pkl file 
-    with open(segmenter.configs["masks_dict_file"], "wb") as file:
-            pickle.dump(frame_masks, file)
+segmenter.run_propagation()

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -4,7 +4,7 @@ import utils
 
 # Specify the path to the configuration YAML file
 # yaml_file_path = "./template_configs.yaml"
-yaml_file_path = "/projects/brre2566/annotator_gui_configs/test_configs.yaml"
+yaml_file_path = "/projects/brre2566/annotator_gui_configs/GX137102_entex_configs.yaml"
 
 # Set device for PyTorch 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -8,6 +8,8 @@ yaml_file_path = "./template_configs.yaml"
 # Set device for PyTorch 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
+# Initialize class using configurations 
 segmenter = SAM2FishSegmenter(configs=yaml_file_path, device=device)
 
+# Run mask propagation workflow 
 segmenter.run_propagation()

--- a/SAM2_Tracking/main.py
+++ b/SAM2_Tracking/main.py
@@ -44,7 +44,7 @@ for fish_label in fish_frame_chunks.index:
     segmenter.add_annotations(annotations=annotation_chunk)
 
     # Run propagation on annotation chunk of frames
-    frame_masks += segmenter.run_propagation(start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)
+    frame_masks += segmenter.get_masks(start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)
 
 if segmenter.configs["save_masks"]: 
     # Save frame_masks as pkl file 

--- a/SAM2_Tracking/sam2_fish_segmenter.py
+++ b/SAM2_Tracking/sam2_fish_segmenter.py
@@ -131,33 +131,32 @@ class SAM2FishSegmenter:
 
         Parameters
         ----------
-        annotations : List of dict
-            List of dictionaries specifying points with keys: 
-            Frame, fishLabel, Location, and clickType
+        annotations : Pandas.DataFrame
+            DataFrame specifying points with index `obj_id_name`
+            and columns: `frame_idx_name`, `points_name`, and 
+            `labels_name`, with values as specified in the 
+            configuration yaml
 
         Raises
         ------
         ValueError
-            If `annotations` was not a `list` of `dict`
+            If `annotations` was not a `Pandas.DataFrame`
 
         Examples
         --------
-        >>> segmenter.add_annotations(annotations=my_annotations)
+        >>> segmenter.add_annotations(annotations=ann_df)
         """
 
-        if not isinstance(annotations, list):
-            raise TypeError("annotations should be of type list!")
+        if not isinstance(annotations, pd.DataFrame):
+            raise TypeError("annotations should be a Pandas DataFrame!")
 
-        for annotation in annotations:
-
-            if not isinstance(annotation, dict):
-                raise TypeError(f"annotations element {annotation} is not of type dict!")
+        for index, row in annotations.iterrows():
 
             # Extract values from the current annotation
-            ann_frame_idx = annotation['Frame']  # Frame index
-            ann_obj_id = int(annotation['fishLabel'])  # Object ID
-            points = np.array([annotation['Location']], dtype=np.float32)  # Point coordinates
-            labels = np.array([annotation['clickType']], dtype=np.int32)  # Positive/Negative click
+            ann_frame_idx = row[self.configs['frame_idx_name']]  # Frame index
+            ann_obj_id = int(index)  # Object ID
+            points = np.array([row[self.configs['points_name']]], dtype=np.float32)  # Point coordinates
+            labels = np.array([row[self.configs['labels_name']]], dtype=np.int32)  # Positive/Negative click
 
             # Explicitly call predictor.add_new_points_or_box for annotation
             # ref: https://github.com/facebookresearch/sam2/blob/2b90b9f5ceec907a1c18123530e92e794ad901a4/sam2/sam2_video_predictor.py#L161

--- a/SAM2_Tracking/sam2_fish_segmenter.py
+++ b/SAM2_Tracking/sam2_fish_segmenter.py
@@ -290,8 +290,8 @@ class SAM2FishSegmenter:
             # Add point annotations for provided annotation chunk 
             self.add_annotations(annotations=annotation_chunk)
 
-            # Run propagation on annotation chunk of frames
-            frame_masks = self.get_masks(frame_masks=frame_masks, start_frame_idx=enter_frame, max_frame_num_to_track=exit_frame)
+            # Run propagation on chunk of annotated frames
+            frame_masks = self.get_masks(frame_masks=frame_masks, start_frame_idx=enter_frame, max_frame_num_to_track=num_frames)
 
         if self.configs["save_masks"]: 
             # Save frame_masks as pkl file 

--- a/SAM2_Tracking/sam2_fish_segmenter.py
+++ b/SAM2_Tracking/sam2_fish_segmenter.py
@@ -256,25 +256,25 @@ class SAM2FishSegmenter:
                                                SAM2_start=self.configs["SAM2_start"], df_columns=df_columns, 
                                                frame_col_name=self.configs["frame_idx_name"])
 
-        # Get object frame chunks and modified annotations 
+        # Get object frame chunks and modified annotations (that have labels_name rows with 3/4 values dropped)
         obj_frame_chunks, annotations = utils.get_frame_chunks_df(df=annotations)
 
         frame_masks = {}
-        for obj_label in obj_frame_chunks.index:   # TODO: need to modify for multiple index values 
+        for obj_label in obj_frame_chunks.index:   # TODO: need to modify for multiple index values and change .loc to .iloc
 
             # Get the enter, exit, and number of frames for obj label 
             enter_frame = fish_frame_chunks.loc[obj_label]['EnterFrame']
             exit_frame = fish_frame_chunks.loc[obj_label]['ExitFrame']
             num_frames = exit_frame - enter_frame
 
-            # Get all of the annotations for the given fishLabel
-            annotation_fish = annotations.loc[obj_label]
+            # Get all of the annotations for the given object label
+            obj_annotation = annotations.loc[obj_label]
 
             # Get all annotations that have Frame values between enter_frame and exit_frame inclusive 
-            annotation_chunk = annotation_fish[(annotation_fish['Frame'] >= enter_frame) & (annotation_fish['Frame'] <= exit_frame)]
+            annotation_chunk = obj_annotation[(obj_annotation[self.configs["frame_idx_name"]] >= enter_frame) & (obj_annotation[self.configs["frame_idx_name"]] <= exit_frame)]
 
             # Reset inference state for the new incoming annotations 
-            self.predictor.reset_state(segmenter.inference_state)    # TODO: might want to skip for the first entry? 
+            self.predictor.reset_state(self.inference_state)    # TODO: might want to skip for the first entry? 
 
             # Add point annotations for provided annotation chunk 
             self.add_annotations(annotations=annotation_chunk)

--- a/SAM2_Tracking/sam2_fish_segmenter.py
+++ b/SAM2_Tracking/sam2_fish_segmenter.py
@@ -285,7 +285,7 @@ class SAM2FishSegmenter:
                 annotation_chunk = obj_annotation[chunk]
 
             # Reset inference state for the new incoming annotations 
-            self.predictor.reset_state(self.inference_state)    # TODO: might want to skip for the first entry? 
+            self.predictor.reset_state(self.inference_state)   
 
             # Add point annotations for provided annotation chunk 
             self.add_annotations(annotations=annotation_chunk)

--- a/SAM2_Tracking/template_configs.yaml
+++ b/SAM2_Tracking/template_configs.yaml
@@ -24,6 +24,18 @@ SAM2_start: 0
 # File specifying annotations for video frames 
 annotations_file: "/path/to/test_annotations.npy" 
 
+# Key in the annotation corresponding to SAM2 frame_idx
+frame_idx_name: 'Frame'
+
+# Key in the annotation corresponding to SAM2 obj_id
+obj_id_name: 'fishLabel'
+
+# Key in the annotation corresponding to SAM2 points
+points_name: 'Location'
+
+# Key in the annotation corresponding to SAM2 labels
+labels_name: 'clickType'
+
 # Whether to offload the video frames to CPU memory.
 # Turning on this option saves the GPU memory with only a very small overhead
 offload_video_to_cpu: True

--- a/SAM2_Tracking/template_configs.yaml
+++ b/SAM2_Tracking/template_configs.yaml
@@ -52,7 +52,11 @@ async_loading_frames: False
 ###########################################
 
 # If True, draw segmentation masks on top of frames and save the generated JPGs to jpg_save_dir
+# Note that jpg_save_dir must have all frames in it, if copy_frame_dir is False
 save_jpgs: True
+
+# If True, will copy the directory specified by frame_dir to jpg_save_dir at runtime 
+copy_frame_dir: True
 
 # The full path to the directory we want to save frames with segmentation masks drawn on them
 jpg_save_dir: './generated_jpgs'

--- a/SAM2_Tracking/template_configs.yaml
+++ b/SAM2_Tracking/template_configs.yaml
@@ -4,9 +4,9 @@ sam2_install_dir: "/path/to/sam2/sam2/"
 # Directory containing JPGs corresponding to the frames of the video
 frame_dir: "/path/to/frames"
 
-################################################
-# initialize_predictor specific configurations #
-################################################
+######################################################
+# build_sam2_video_predictor specific configurations #
+######################################################
 
 sam2_checkpoint: "/path/to/sam2/checkpoints/sam2.1_hiera_large.pt"
 model_cfg: "configs/sam2.1/sam2.1_hiera_l.yaml"
@@ -15,10 +15,15 @@ model_cfg: "configs/sam2.1/sam2.1_hiera_l.yaml"
 non_overlap_masks: False
 
 ########################################
-# predict_mask specific configurations #
+# annotation specific configurations   #
 ########################################
 
+# The FPS of the unreduced video that the annotations were 
+# initially meant for
 fps: 24
+
+# Value the ensures the annotated frame value matches up 
+# with the fames that will be ingested by SAM2
 SAM2_start: 0
 
 # File specifying annotations for video frames 
@@ -35,6 +40,10 @@ points_name: 'Location'
 
 # Key in the annotation corresponding to SAM2 labels
 labels_name: 'clickType'
+
+#################################################
+# set_inference_state specific configurations   #
+#################################################
 
 # Whether to offload the video frames to CPU memory.
 # Turning on this option saves the GPU memory with only a very small overhead

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -150,30 +150,24 @@ def get_frame_chunks_df(df=None, obj_name=None, frame_name=None, click_type_name
     exit_frame = df[df[click_type_name] == 4][[obj_name, frame_name]].astype(int) 
     exit_frame = exit_frame.sort_values(by=[obj_name, frame_name], ascending=True)
 
-    # TODO: drop obj_name from exit_frame 
-
-    print(enter_frame.shape)
-    print(exit_frame.shape)
-
-    print(enter_frame)
-    print(exit_frame)
-
-    if (enter_frame.shape != exit_frame.shape) or np.array_equal(enter_frame[obj_name].values, exit_frame[obj_name].values):
+    # Check that each enter point has a corresponding exit point
+    if (enter_frame.shape != exit_frame.shape) or (not np.array_equal(enter_frame[obj_name].values, exit_frame[obj_name].values)):
         raise RuntimeError(f"A {obj_name} does not have both an enter and exit point!")
+
+    # Drop obj_name from exit_frame, now that we have sorted and compared them
+    exit_frame.drop(columns=obj_name, axis=1, inplace=True)
+
+    # Turn obj_name column back to a string 
+    enter_frame[obj_name] = enter_frame[obj_name].astype(str) 
 
     # Concatenate columns to improve ease of use later
     obj_frame_chunks = pd.concat([enter_frame.reset_index(drop=True), exit_frame.reset_index(drop=True)], axis=1)
     obj_frame_chunks.columns = [obj_name, 'EnterFrame', 'ExitFrame']
 
-    print(obj_frame_chunks)
-
     # Drop df rows that have click_type_name values of 3 or 4
     df = df[~df[click_type_name].isin([3, 4])]
 
-    # Reset index of obj_frame_chunks (improves downstream processing)
-    # obj_frame_chunks = obj_frame_chunks.reset_index()
-
-    # Modify the incoming df so it has obj_name as its index
+    # Modify df so it has obj_name as its index
     df = df.set_index(obj_name)
 
     return obj_frame_chunks, df

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -194,10 +194,10 @@ def get_jpg_paths(jpg_dir):
 
     return sorted(jpg_paths)
 
-def draw_and_save_frame_seg(bool_masks, img_save_dir, frame_paths, out_frame_idx, out_obj_ids, colors, 
+def draw_and_save_frame_seg(bool_masks, jpg_save_dir, frame_paths, out_frame_idx, out_obj_ids, colors, 
                             font_size=75, font_color="red", alpha=0.6):
     """
-    Draws segmentation masks on top of the frame and saves 
+    Draws segmentation masks on top of the frames and saves 
     the generated image to `img_save_dir`. 
 
     Parameters
@@ -205,8 +205,8 @@ def draw_and_save_frame_seg(bool_masks, img_save_dir, frame_paths, out_frame_idx
     bool_masks : Tensor of bools
         A tensor of shape (number of masks, frame pixel height, frame pixel width)
         representing the generated segmentation masks
-    img_save_dir : str
-        The path where we want to save the generated image
+    jpg_save_dir : str
+        The path containing frames that will be overwritten with the masks
     frame_paths : list of str
         A list of JPG paths representing the frames 
     out_frame_idx : int
@@ -228,13 +228,16 @@ def draw_and_save_frame_seg(bool_masks, img_save_dir, frame_paths, out_frame_idx
         List of sorted JPG paths
     """    
 
+    # Get frame name using the stem of the frame JPG
+    frame_id = Path(frame_paths[out_frame_idx]).stem
+
     # Draw each mask on top of image representing the frame
-    image_w_seg = decode_image(frame_paths[out_frame_idx])
+    image_w_seg = decode_image(jpg_save_dir + f"/{frame_id}.jpg")
     for i in range(bool_masks.shape[0]):
 
         # Only draw masks that contain True values 
         if bool_masks[i].any():
-            image_w_seg = draw_segmentation_masks(image_w_seg, bool_masks[i], colors=colors[i], alpha=alpha)
+            image_w_seg = draw_segmentation_masks(image_w_seg, bool_masks[i], colors=colors[out_obj_ids[i]], alpha=alpha)
 
     # Convert image with drawn segmentation masks to PIL Image
     to_pil = transforms.ToPILImage()
@@ -252,11 +255,8 @@ def draw_and_save_frame_seg(bool_masks, img_save_dir, frame_paths, out_frame_idx
         if centroid:
             draw.text(centroid, str(label), fill=font_color, font=font)
 
-    # Get frame name using the stem of the frame JPG
-    frame_id = Path(frame_paths[out_frame_idx]).stem
-
     # Save the final image
-    img_pil.save(img_save_dir + f"/{frame_id}.jpg")
+    img_pil.save(jpg_save_dir + f"/{frame_id}.jpg")
 
 def write_output_video(masked_imgs_dir, video_file, video_fps, video_frame_size):
     """

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -143,8 +143,7 @@ def get_frame_chunks_df(df=None, obj_name=None, frame_name=None, click_type_name
     # TODO: check types of inputs 
 
     # Modify the incoming df so it has obj_name as its index
-    # TODO: should we do this inplace? 
-    df = df.set_index(obj_name).  # TODO: may want to remove this. 
+    df = df.set_index(obj_name)
 
     # For each obj_name get frame where the object enters the scene 
     enter_frame = df[df[click_type_name] == 3][frame_name]
@@ -165,8 +164,10 @@ def get_frame_chunks_df(df=None, obj_name=None, frame_name=None, click_type_name
     obj_frame_chunks.columns = ['EnterFrame', 'ExitFrame']
 
     # Drop df rows that have click_type_name values of 3 or 4
-    # TODO: should we do this inplace? 
     df = df[~df[click_type_name].isin([3, 4])]
+
+    # Reset index of obj_frame_chunks (improves downstream processing)
+    obj_frame_chunks = obj_frame_chunks.reset_index()
 
     return obj_frame_chunks, df
 

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -144,19 +144,19 @@ def get_frame_chunks_df(df=None, obj_name=None, frame_name=None, click_type_name
 
     # For each obj_name get frame where the object enters the scene 
     enter_frame = df[df[click_type_name] == 3][[obj_name, frame_name]].astype(int) 
-    enter_frame = enter_frame.sort_values(by=obj_name, ascending=True)
+    enter_frame = enter_frame.sort_values(by=[obj_name, frame_name], ascending=True)
     
     # For each obj_name get frame where the object exits the scene 
     exit_frame = df[df[click_type_name] == 4][[obj_name, frame_name]].astype(int) 
-    exit_frame = exit_frame.sort_values(by=obj_name, ascending=True)
+    exit_frame = exit_frame.sort_values(by=[obj_name, frame_name], ascending=True)
 
     # TODO: drop obj_name from exit_frame 
 
     print(enter_frame.shape)
     print(exit_frame.shape)
 
-    print(enter_frame[obj_name].values)
-    print(exit_frame[obj_name].values)
+    print(enter_frame)
+    print(exit_frame)
 
     if (enter_frame.shape != exit_frame.shape) or np.array_equal(enter_frame[obj_name].values, exit_frame[obj_name].values):
         raise RuntimeError(f"A {obj_name} does not have both an enter and exit point!")

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -144,7 +144,7 @@ def get_frame_chunks_df(df=None, obj_name=None, frame_name=None, click_type_name
 
     # Modify the incoming df so it has obj_name as its index
     # TODO: should we do this inplace? 
-    df = df.set_index(obj_name)
+    df = df.set_index(obj_name).  # TODO: may want to remove this. 
 
     # For each obj_name get frame where the object enters the scene 
     enter_frame = df[df[click_type_name] == 3][frame_name]


### PR DESCRIPTION
In its current state, the SAM2 segmentation performs poorly when ran on the whole video with all object IDs provided. The complexity of this task is not possible with an untrained SAM2 model. For this reason, in this PR we use a modified strategy. During annotations, we will now mark the enter and exit frame for each object ID. The code in this PR then uses this annotation strategy to only run SAM2 video propagation over a single object ID on the frames between the enter and exit frames, inclusive. This strategy drastically improves the results produced as well as reduces the runtime. To achieve this goal, the following items were completed: 

- Replaced `filter_annotations` with `adjust_annotations` function that reframes the function to use Pandas DataFrames
    - In its current state, frame values are always rounded and no warning is provided. If a warning is necessary, an issue should be created for this. 
- Added `utils.py` function `get_frame_chunks_df` that obtains the chunks of the provided object where it enter/exits the scene and modifies incoming df so index is appropriately set and click type equal to 3 and 4 are dropped 
    - This function will also raise an error if each enter frame does not have an accompanying exit frame
- Included `obj_id_name`, `frame_idx_name`, `points_name`, and `labels_name` in configuration file, which represent annotation keys that correspond to SAM2 values. This prevents the hard coding of values and increases generalization of the codebase. 
- Modified `add_annotations` so that it uses new DataFrame format for annotations and uses new configuration file variables for annotation keys
- Created new configuration variable `copy_frame_dir`. If `True` then during initialization of `SAM2FishSegmenter` we will copy `frame_dir` to `jpg_save_dir`. 
    - IMPORTANT! This functionality modifies the original behavior of the class. It is necessary so that we can efficiently draw the masks on the frames during runtime. Note that this copy can take a long time, if ran in slow storage spaces or the `frame_dir` is large. 
- Modified `draw_and_save_frame_seg` so it overwrites the frame found in `jpg_save_dir` (corresponding to the frames in frame_dir)
-  In `draw_and_save_frame_seg` replaced `colors=colors[i]` with `colors=colors[out_obj_ids[i]]`, which provides the same color to the fish based on the object ID
- Renamed `run_propagation` to `get_masks`. Where `get_masks` now performs `propagate_in_video` over a specified `start_frame_idx` and `max_frame_num_to_track`
- Modified `get_masks` so that it now takes `frame_masks` as an input and adds items to this dictionary, if `save_masks=True`. It then returns the modified `frame_masks`
    - IMPORTANT! This is a change in functionality compared to the previous codebase 
- Create `run_propagation` function that runs entire workflow, including grabbing the annotations, getting the annotation chunks, adding the annotations to the predictor, and initiating the propagation. 
    - IMPORTANT! This is a change in functionality as well


NOTE: as Pandas is critical to splitting up the annotations into chunks, it has become a dependency going forward.  