### PR TITLE
Efficiently create masked video

### DIFF
--- a/SAM2_Tracking/create_video.py
+++ b/SAM2_Tracking/create_video.py
@@ -1,10 +1,16 @@
 from utils import read_config_yaml, write_output_video
+import torch 
 
 # Specify the path to the configuration YAML file
 yaml_file_path = "./template_configs.yaml"
 
+# Set device for PyTorch 
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
 # Read and load the configuration YAML
 configs = read_config_yaml(yaml_file_path)
 
-write_output_video(masked_imgs_dir=configs["jpg_save_dir"], video_file=configs["video_file"], 
-                   video_fps=configs["video_fps"], video_frame_size=configs["video_frame_size"])
+write_output_video(frame_dir=configs["frame_dir"], frame_masks_file=configs["masks_dict_file"], 
+                   video_file=configs["video_file"], video_fps=configs["video_fps"], 
+                   video_frame_size=configs["video_frame_size"], font_size=configs["font_size"], 
+                   font_color=configs["font_color"], alpha=configs["alpha"], device=device)

--- a/SAM2_Tracking/template_configs.yaml
+++ b/SAM2_Tracking/template_configs.yaml
@@ -19,10 +19,10 @@ non_overlap_masks: False
 ########################################
 
 # The FPS of the unreduced video that the annotations were 
-# initially meant for
+# initially created for
 fps: 24
 
-# Value the ensures the annotated frame value matches up 
+# Value that ensures the annotated frame value matches up 
 # with the fames that will be ingested by SAM2
 SAM2_start: 0
 
@@ -60,31 +60,8 @@ async_loading_frames: False
 # run_propagation specific configurations #
 ###########################################
 
-# If True, draw segmentation masks on top of frames and save the generated JPGs to jpg_save_dir
-# Note that jpg_save_dir must have all frames in it, if copy_frame_dir is False
-save_jpgs: True
-
-# If True, will copy the directory specified by frame_dir to jpg_save_dir at runtime 
-copy_frame_dir: True
-
-# The full path to the directory we want to save frames with segmentation masks drawn on them
-jpg_save_dir: './generated_jpgs'
-
-# If True, save the generated masks in a dictionary with sparse tensor values and save it as 
-# a pkl file defined by masks_dict_file
-save_masks: True
-
-# The location you want to save the dictionary of masks 
+# The location you want to save the dictionary of masks to
 masks_dict_file: './generated_frame_masks.pkl'
-
-# Font size for drawn object IDs
-font_size: 100
-
-# Color of font for the drawn object IDs
-font_color: "red"
-
-# Alpha value for the drawn segmentation masks
-alpha: 0.6
 
 ###################################
 # Video creation specific configs #
@@ -93,9 +70,18 @@ alpha: 0.6
 # The name of the video file to be created
 video_file: "./test_video.mp4"
 
+# Font size for drawn object IDs
+font_size: 16
+
+# Color of font for the drawn object IDs
+font_color: "red"
+
+# Alpha value for the drawn segmentation masks
+alpha: 0.6
+
 # The frames per second for the video 
 video_fps: 3
 
 # Specifies the frame size for the video, with the first element 
 # representing the width and the second corresponding to the height
-video_frame_size: [600, 400]
+video_frame_size: [900, 600]

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -13,8 +13,6 @@ import matplotlib.pyplot as plt
 from tqdm import tqdm
 import pandas as pd 
 import pickle
-import time 
-import warnings
 
 def read_config_yaml(config_path):
     """
@@ -116,7 +114,7 @@ def adjust_annotations(annotations_file=None, fps=None, SAM2_start=None,
         rounded_values = original_values[rounded_indices]
         new_values = df.loc[rounded_indices, frame_col_name]
         for original, new in zip(rounded_values, new_values):
-            warnings.warn(f"Warning: Frame value {original} was rounded to {new}.", RuntimeWarning)
+            print(f"Frame value {original} was rounded to {new}.")
 
     return df  
 

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 import pandas as pd 
 import pickle
 import time 
+import warnings
 
 def read_config_yaml(config_path):
     """
@@ -68,6 +69,12 @@ def adjust_annotations(annotations_file=None, fps=None, SAM2_start=None,
         DataFrame with columns `df_columns` with column 
         `frame_col_name` adjusted
 
+    Raises
+    ------
+    RuntimeWarning
+        If adjustment of frame values results in frame 
+        values that need to be rounded 
+
     Examples
     --------
     >>> annotations_file = "./my_annotations.npy"
@@ -109,7 +116,7 @@ def adjust_annotations(annotations_file=None, fps=None, SAM2_start=None,
         rounded_values = original_values[rounded_indices]
         new_values = df.loc[rounded_indices, frame_col_name]
         for original, new in zip(rounded_values, new_values):
-            print(f"Warning: Frame value {original} was rounded to {new}.")
+            warnings.warn(f"Warning: Frame value {original} was rounded to {new}.", RuntimeWarning)
 
     return df  
 

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -114,7 +114,7 @@ def adjust_annotations(annotations_file=None, fps=None, SAM2_start=None,
         rounded_values = original_values[rounded_indices]
         new_values = df.loc[rounded_indices, frame_col_name]
         for original, new in zip(rounded_values, new_values):
-            print(f"Frame value {original} was rounded to {new}.")
+            print(f"Warning: Frame value {original} was rounded to {new}.")
 
     return df  
 


### PR DESCRIPTION
This PR addresses the inefficiency concerns raised in issue #14. While investigating more efficient ways to retrieve and store the JPG frames (such as tar files), it became very clear that creating a directory with masked JPG frames would result in an inefficient use of memory. Additionally, any efficient techniques would result in clunky code. 

As a result of this investigation, I decided to remove the creation of JPGs that was occurring in the `run_propagation` function. Instead, a more straightforward approach is to save the generated `frame_masks` and then utilize this dictionary of masks later when we create the video. We previously had this workflow, but inefficient handling of `frame_masks` and creation of the video resulted in memory explosion and a significant runtime for the creation of the video. Now that we have tensors representing the masks, we can utilize more efficient PyTorch functions to apply the masks and feed said masks to cv2 for video writing. By turning to this approach, one can create a more streamlined pipeline for processing. 

To achieve the chosen approach, the following items were completed: 
- Removed masked JPG generation in `get_masks` routine
    - `frame_masks` will now be automatically generated and saved to the location specified by the configuration variable `masks_dict_file`
    -  As a result, I removed the configuration options for creating the JPG directory and turning off the saving of `frame_masks`. I then modified all routines accordingly. 
- Removed `draw_and_save_frame_seg` function
    - This function was replaced by the `draw_masks` routine, which draws masks on a specified image
- Modified `write_output_video` so that it creates the MP4 using all frames in `frame_dir` and draws masks on frames if they exist
    - This can be efficiently done due to tensor operations and does not require us to create a holding place for JPGs with masks drawn on them 