### PR TITLE
Make extracted frame rate a variable for all scripts

### DIFF
--- a/LocalAnnotationBitesGUI_0226.py
+++ b/LocalAnnotationBitesGUI_0226.py
@@ -24,6 +24,7 @@ frames = []
 vid_height, vid_width = 0, 0
 fps = 30  # Default FPS, will update dynamically based on video
 special_frame_start = 0  # Default starting frame for SAM2
+out_fps = 3 # Default extracted frame rate for SAM2
 special_frame_interval = 10  # Default, will calculate dynamically
 ObjType = ["Parrotfish"]  # Default fish family
 
@@ -55,7 +56,7 @@ def load_video():
     frames.clear()
 
     fps = cap.get(cv2.CAP_PROP_FPS) or 30  # Update FPS dynamically
-    special_frame_interval = max(1, round(fps) / 3)  # Calculate interval for 3 frames per second
+    special_frame_interval = max(1, round(fps) / out_fps)  # Calculate interval for the SAM2 extracted frame rate
 
     while cap.isOpened():
         ret, frame = cap.read()

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The current time, current frame, and playback speed are shown at the top of the 
 
 The SAM2 Start Frame is a function for ensuring that the annotated frames correspond with the frames extracted for SAM2. The SAM2 Start Frame specifies which frame to begin counting at, then will display a message "SAM2 Frame: Annotate Fish Position" on the 3 frames per second that will be processed by SAM2.
 > [!Note] 
-> It is assumed (and hard-coded within this GUI function) that frames will be extracted from the raw video at 3 FPS. 
-> If a different temporal resolution is desired, line 58 of `LocalAnnotationBitesGUI_0226.py` can be edited to adjust the `special_frame_interval`. 
+> It is the default assumption that frames will be extracted from the raw video at 3 FPS. 
+> If a different temporal resolution is desired, line 27 of `LocalAnnotationBitesGUI_0226.py` can be edited to adjust the `out_fps`. 
 As a default, the SAM2 Start Frame will be 0, and can remain as 0 for videos where left-right video syncing has already been completed or is not necessary. 
 
 ### Click Types

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ A folder should be set up containing the `annotations.npy` file, the `frames` su
 
 The `template_configs.yaml` file should be edited to specify the paths to the SAM2 installation and provided checkpoints, the FPS of the original video that was annotated in the GUI, the `SAM2_start` frame that was used in both the GUI and the Extract Frames step, and the name of the annotations NumPy file. 
 
-Lines 32 - 42 specify the key used in the annotations file created by the GUI. The most recent GUI uses different labels than previous versions and these may need to be altered:
+Lines 35 - 45 specify the key used in the annotations file created by the GUI. The most recent GUI uses different labels than previous versions and these may need to be altered:
 ```
 # Key in the annotation corresponding to SAM2 
 frame_idx_name: 'Frame'
@@ -163,7 +163,7 @@ points_name: 'Location'
 labels_name: 'ClickType'
 ```
 
-If a different extracted frame rate has been used (i.e., other than 3 FPS), change the `video_fps` value on line 83. 
+If a different extracted frame rate has been used (i.e., other than 3 FPS), change the `out_fps` value on line 30. 
 
 Other values in the `template_configs.yaml` can be left as the default, or can be changed as desired. 
 
@@ -173,6 +173,10 @@ mamba activate sam2-env
 python3 main.py
 ```
 
-If default values are used, when the code is done running, it should produce a `test_video.mp4` displaying all the predicted masks; this video can be viewed to validate SAM2 predictions. The actual masks are saved as a dictionary of sparse tensors within `generated_frame_masks.pkl`.
-
+If default values are used, when the code is done running, it should produce a dictionary of sparse tensors within `generated_frame_masks.pkl`. To visualize the generated masks, create a `test_video.mp4` displaying all the predicted masks:
+```
+mamba activate sam2-env
+python3 create_video.py
+```
+This video can be viewed to validate SAM2 predictions.
 Please raise an issue or contact M.Hair if you experience issues using this code. 

--- a/SAM2_Tracking/create_video.py
+++ b/SAM2_Tracking/create_video.py
@@ -11,7 +11,7 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 configs = read_config_yaml(yaml_file_path)
 
 write_output_video(frame_dir=configs["frame_dir"], frame_masks_file=configs["masks_dict_file"], 
-                   video_file=configs["video_file"], video_fps=configs["video_fps"], 
+                   video_file=configs["video_file"], out_fps=configs["out_fps"], 
                    video_frame_size=configs["video_frame_size"], fps=configs["fps"],
                    SAM2_start=configs["SAM2_start"], font_size=configs["font_size"], 
                    font_color=configs["font_color"], alpha=configs["alpha"], device=device)

--- a/SAM2_Tracking/sam2_fish_segmenter.py
+++ b/SAM2_Tracking/sam2_fish_segmenter.py
@@ -233,8 +233,8 @@ class SAM2FishSegmenter:
 
         # Convert annotations to a DataFrame and adjust frame values 
         annotations = utils.adjust_annotations(annotations_file=self.configs["annotations_file"], fps=self.configs["fps"], 
-                                               SAM2_start=self.configs["SAM2_start"], df_columns=df_columns, 
-                                               frame_col_name=self.configs["frame_idx_name"])
+                                               out_fps = self.configs["out_fps"], SAM2_start=self.configs["SAM2_start"], 
+                                               df_columns=df_columns, frame_col_name=self.configs["frame_idx_name"])
 
         # Get object frame chunks and modified annotations (that have labels_name rows with 3/4 values dropped)
         obj_frame_chunks, annotations = utils.get_frame_chunks_df(df=annotations, obj_name=self.configs["obj_id_name"], 

--- a/SAM2_Tracking/template_configs.yaml
+++ b/SAM2_Tracking/template_configs.yaml
@@ -26,6 +26,9 @@ fps: 24
 # with the fames that will be ingested by SAM2
 SAM2_start: 0
 
+# Reduced frame rate. Must match with the extracted frame rate.
+out_fps: 3
+
 # File specifying annotations for video frames 
 annotations_file: "/path/to/test_annotations.npy" 
 
@@ -78,9 +81,6 @@ font_color: "red"
 
 # Alpha value for the drawn segmentation masks
 alpha: 0.6
-
-# The frames per second for the video. Should also be the frame rate of extraction. 
-video_fps: 3
 
 # Specifies the frame size for the video, with the first element 
 # representing the width and the second corresponding to the height


### PR DESCRIPTION
Replace video_fps with out_fps and any hard-coded 3's as the out_fps in the SAM2 and Annotator GUI scripts. This will allow users to easily modulate to a different temporal resolution in the GUI, the Extract Frames script, and the main SAM2 workflow.