### PR TITLE
Batching

### DIFF
--- a/LocalAnnotationBitesGUI_0226.py
+++ b/LocalAnnotationBitesGUI_0226.py
@@ -24,7 +24,6 @@ frames = []
 vid_height, vid_width = 0, 0
 fps = 30  # Default FPS, will update dynamically based on video
 special_frame_start = 0  # Default starting frame for SAM2
-out_fps = 3 # Default extracted frame rate for SAM2
 special_frame_interval = 10  # Default, will calculate dynamically
 ObjType = ["Parrotfish"]  # Default fish family
 
@@ -56,7 +55,7 @@ def load_video():
     frames.clear()
 
     fps = cap.get(cv2.CAP_PROP_FPS) or 30  # Update FPS dynamically
-    special_frame_interval = max(1, round(fps) / out_fps)  # Calculate interval for the SAM2 extracted frame rate
+    special_frame_interval = max(1, round(fps) / 3)  # Calculate interval for 3 frames per second. Can substitute 3 for your desired frame extraction rate. 
 
     while cap.isOpened():
         ret, frame = cap.read()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The current time, current frame, and playback speed are shown at the top of the 
 The SAM2 Start Frame is a function for ensuring that the annotated frames correspond with the frames extracted for SAM2. The SAM2 Start Frame specifies which frame to begin counting at, then will display a message "SAM2 Frame: Annotate Fish Position" on the 3 frames per second that will be processed by SAM2.
 > [!Note] 
 > It is the default assumption that frames will be extracted from the raw video at 3 FPS. 
-> If a different temporal resolution is desired, line 27 of `LocalAnnotationBitesGUI_0226.py` can be edited to adjust the `out_fps`. 
+> If a different temporal resolution is desired, line 58 of `LocalAnnotationBitesGUI_0226.py` can be edited to change `3`to your desired extraction frame rate. 
 As a default, the SAM2 Start Frame will be 0, and can remain as 0 for videos where left-right video syncing has already been completed or is not necessary. 
 
 ### Click Types

--- a/SAM2_Tracking/create_video_batch.py
+++ b/SAM2_Tracking/create_video_batch.py
@@ -1,0 +1,60 @@
+from utils import read_config_yaml, write_output_video, extract_keys, get_trial_value
+import torch 
+
+# Specify the path to the configuration YAML file
+configs = "./template_configs.yaml"
+
+# Set device for PyTorch 
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def run_batch_video_processing(configs, device):
+    # Load the YAML configuration file
+    configs = read_config_yaml(configs)
+    
+    # Retrieve list of configuration keys
+    keys = extract_keys(configs)
+    
+    # Extract lists of main relevant parameters
+    frame_dirs = configs.get("frame_dir", [])
+    mask_files = configs.get("masks_dict_file", [])
+    video_files = configs.get("video_file", [])
+    
+    # Ensure main lists are of the same length
+    if not (len(frame_dirs) == len(mask_files) == len(video_files)):
+        raise ValueError("Mismatch between number of frame directories, mask files, and video files")  
+        
+    # Calculate number of trials
+    trial_count = len(frame_dirs)
+    print(f"Number of videos to create: {trial_count}")
+    
+    # Create list of trials
+    trials = list(zip(frame_dirs, mask_files, video_files))
+    
+    # Run video creation for each trial
+    for frame_dir, mask_file, video_file in trials:
+        print(f"Creating video: {video_file} from {frame_dir} and {mask_file}")
+        trial_config = configs.copy()
+        
+        # Get trial index
+        i = trials.index((frame_dir, mask_file, video_file))
+    
+        # Iterate through configuration keys check for any other values that changed between trials
+        for key in keys:
+            trial_config[key] = get_trial_value(configs, key, i, trial_count)
+
+        write_output_video(
+            frame_dir = trial_config["frame_dir"],
+            frame_masks_file = trial_config["masks_dict_file"],
+            video_file=trial_config["video_file"],
+            out_fps=trial_config["out_fps"],
+            video_frame_size=configs["video_frame_size"],
+            fps=trial_config["fps"],
+            SAM2_start=trial_config["SAM2_start"],
+            font_size=trial_config["font_size"],
+            font_color=trial_config["font_color"],
+            alpha=trial_config["alpha"],
+            device=device
+            )
+
+run_batch_video_processing(configs, device)

--- a/SAM2_Tracking/create_video_batch.py
+++ b/SAM2_Tracking/create_video_batch.py
@@ -2,7 +2,7 @@ from utils import read_config_yaml, write_output_video, extract_keys, get_trial_
 import torch 
 
 # Specify the path to the configuration YAML file
-configs = "./template_configs.yaml"
+configs = "./template_configs_batch.yaml"
 
 # Set device for PyTorch 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/SAM2_Tracking/main_batch.py
+++ b/SAM2_Tracking/main_batch.py
@@ -1,0 +1,55 @@
+import yaml
+import torch
+import utils
+from sam2_fish_segmenter import SAM2FishSegmenter
+
+def run_batch_processing(config_file, device):
+    # Load the YAML configuration file
+    configs = utils.read_config_yaml(config_file)
+    
+    # Retrieve list of configuration keys
+    keys = utils.extract_keys(configs)
+    
+    # Extract lists of frame directories, annotation files, and output files
+    frame_dirs = configs.get("frame_dir", [])
+    annotation_files = configs.get("annotations_file", [])
+    mask_files = configs.get("masks_dict_file", [])
+    video_files = configs.get("video_file", [])
+    
+    # Ensure main lists are of the same length
+    if not (len(frame_dirs) == len(mask_files) == len(annotation_files) == len(video_files)):
+        raise ValueError("Mismatch between number of annotation files, frame directories, mask files, and video files")  
+        # Note: the video files are not used in this script, but will be used later in create_video.py, and 
+        # I think it's better to be aware of this issue before proceeding.  
+        
+    # Calculate number of trials    
+    trial_count = len(frame_dirs)
+    print(f"Number of trials to process: {trial_count}")
+    
+    trials = list(zip(frame_dirs, annotation_files, mask_files))
+    
+    # Iterate over each trial and run segmentation
+    for frame_dir, annotation_file, mask_file in trials: 
+        trial_config = configs.copy()
+        trial_config["frame_dir"] = frame_dir
+        trial_config["annotations_file"] = annotation_file
+        trial_config["masks_dict_file"] = mask_file
+        
+        # Get trial index
+        i = trials.index((frame_dir, annotation_file, mask_file))
+        
+        # Iterate through configuration keys check for any other values that changed between trials
+        for key in keys:
+            trial_config[key] = utils.get_trial_value(configs, key, i, trial_count)
+        
+        # Initialize the segmenter with modified trial configs
+        segmenter = SAM2FishSegmenter(configs = trial_config, device = device)
+        print(f"Processing: {frame_dir} with {annotation_file} and saving masks to {mask_file}")
+        segmenter.run_propagation()
+
+configs= "./batch_template_configs.yaml"
+        
+# Set device for PyTorch
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+run_batch_processing(configs, device)

--- a/SAM2_Tracking/template_configs_batch.yaml
+++ b/SAM2_Tracking/template_configs_batch.yaml
@@ -1,0 +1,97 @@
+# Specifying SAM2 install directory location 
+sam2_install_dir: "/path/to/sam2/sam2/"
+
+# Directories containing JPGs corresponding to the frames of the video
+frame_dir: 
+    - "/path/to/frames/trial1"
+    - "/path/to/frames/trial2"
+
+######################################################
+# build_sam2_video_predictor specific configurations #
+######################################################
+
+sam2_checkpoint: "/path/to/sam2/checkpoints/sam2.1_hiera_large.pt"
+model_cfg: "configs/sam2.1/sam2.1_hiera_l.yaml"
+
+# Whether to apply non-overlapping constraints on the output object masks
+non_overlap_masks: False
+
+########################################
+# annotation specific configurations   #
+########################################
+
+# The FPS of the unreduced video that the annotations were 
+# initially created with
+fps: 24
+
+# Value that ensures the annotated frame value matches up 
+# with the fames that will be ingested by SAM2
+SAM2_start: 
+    - 0 # Trial 1 SAM2 start
+    - 2 # Trial 2 SAM2 start
+
+# Reduced frame rate. Must match with the extracted frame rate.
+out_fps: 3
+
+# File specifying annotations for video frames 
+annotations_file: 
+    - "/path/to/test_annotations_trial1.npy" 
+    - "/path/to/test_annotations_trial2.npy" 
+    
+# Key in the annotation corresponding to SAM2 frame_idx
+frame_idx_name: 'Frame'
+
+# Key in the annotation corresponding to SAM2 obj_id
+obj_id_name: 'ObjID'
+
+# Key in the annotation corresponding to SAM2 points
+points_name: 'Location'
+
+# Key in the annotation corresponding to SAM2 labels
+labels_name: 'ClickType'
+
+#################################################
+# set_inference_state specific configurations   #
+#################################################
+
+# Whether to offload the video frames to CPU memory.
+# Turning on this option saves the GPU memory with only a very small overhead
+offload_video_to_cpu: True
+
+# Whether to offload the state to CPU memory. 
+# Turning this option on can save GPU memory
+offload_state_to_cpu: True
+
+# Lazy load images, can conserve memory, if it is needed
+async_loading_frames: False
+
+###########################################
+# run_propagation specific configurations #
+###########################################
+
+# The location you want to save the dictionary of masks to
+masks_dict_file: 
+    - './trial_1_generated_frame_masks.pkl'
+    - './trial_2_generated_frame_masks.pkl'
+
+###################################
+# Video creation specific configs #
+###################################
+
+# The name of the video file to be created
+video_file: 
+    - "./trial_1_test_video.mp4"
+    - "./trial_2_test_video.mp4"
+    
+# Font size for drawn object IDs
+font_size: 16
+
+# Color of font for the drawn object IDs
+font_color: "red"
+
+# Alpha value for the drawn segmentation masks
+alpha: 0.6
+
+# Specifies the frame size for the video, with the first element 
+# representing the width and the second corresponding to the height
+video_frame_size: [900, 600]

--- a/SAM2_Tracking/utils.py
+++ b/SAM2_Tracking/utils.py
@@ -35,6 +35,89 @@ def read_config_yaml(config_path):
 
     return config
 
+
+def extract_keys(data, prefix=""):
+    """
+    Recursively extracts all key names from a nested dictionary (YAML configuration).
+
+    Parameters
+    ----------
+    data : dict
+        The dictionary (parsed from YAML) from which to extract key names.
+    prefix : str, optional
+        A prefix used for constructing full key paths when handling nested dictionaries.
+        Defaults to an empty string.
+
+    Returns
+    -------
+    list of str
+        A list containing all key names, including nested keys represented in dot notation.
+
+    Examples
+    --------
+    >>> yaml_data = {"sam2_install_dir": "/path/to/sam2", 
+                     "model_cfg": "config.yaml", 
+                     "nested": {"key1": "value1", "key2": "value2"}}
+    >>> extract_keys(yaml_data)
+    ['sam2_install_dir', 'model_cfg', 'nested.key1', 'nested.key2']
+    """
+    keys = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            full_key = f"{prefix}{key}"
+            keys.append(full_key)
+            keys.extend(extract_keys(value, prefix=full_key + ".") if isinstance(value, dict) else [])
+    return keys
+
+
+ def get_trial_value(config, key, index, trial_count):
+    """
+    Return the value for a given key for the trial at index.
+    If the value is a list:
+       - If its length is 1, return the single value.
+       - If its length equals trial_count, return the value at the current index.
+       - Otherwise, raise an error.
+    If the value is not a list, return it directly.
+    
+    Parameters
+    ----------
+    config : dict
+        A dictionary containing all configuration key-value pairs. This dictionary
+        may include keys with values that are either a single value or a list of values.
+    key : str
+        The configuration key whose value is to be retrieved. This key should be present
+        in the config dictionary.
+    index : int
+        The index of the current trial. This is used to select the appropriate value from
+        a list if the configuration value for the key is provided as a list of values.
+    trial_count : int
+        The total number of trials expected. This is used to verify that if the configuration
+        value for the key is a list, its length matches the number of trials (unless it is a single-element list).
+    
+    Returns
+    -------
+    value : any
+        The configuration value for the specified key corresponding to the current trial.
+        If the value in the configuration is a list with one element, that element is returned;
+        if it is a list with a length equal to trial_count, the element at the given index is returned;
+        otherwise, if the value is not a list, it is returned directly.
+
+    Raises
+    ------
+    ValueError
+        If the configuration value is a list whose length is not 1 or equal to trial_count.
+    """
+    val = config.get(key)
+    if isinstance(val, list):
+        if len(val) == 1:
+            return val[0]
+        elif len(val) == trial_count:
+            return val[index]
+        else:
+            raise ValueError(f"Expected 1 or {trial_count} values for '{key}', got {len(val)}")
+    return val
+
+
 def adjust_annotations(annotations_file=None, fps=None, out_fps=None, SAM2_start=None, 
                        df_columns=None, frame_col_name=None):
     """


### PR DESCRIPTION
This PR incorporates new scripts and functions to allow users to process multiple trials in a single batch. Each trial must have a folder of frames, an annotations.npy file, and a unique name for the masks.pkl results and output_video.mp4. There may be many ways to improve the processing efficiency of the for loops that iterate over a batch of trials.

### New functions in utils.py:
extract_keys: This takes the ingested configuration data and extracts a list of all the key names. This list of keys is used in conjunction with the get_trial_value to automatically check which values in the configuration file are provided as a list or a single value.

get_trial_value: This checks each provided key to determine if it is a single value that should be applied to each trial, or a list equal to the number of trials, in which case the function will return the value for the current trial index . If the length of provided values is neither the same as the expected number of trials nor 1, it will raise an error. 

### New batch template configurations file: 
This file demonstrates how to list multiple values for any given configuration key. For each trial, there **must** be a unique value for the folder of frames, the annotations.npy file, the name for the masks.pkl results, and the name for the output video.  Any other keys in the template_configs can either be provided a single value (which will be applied to all trials in the batch) or a value for each trial. 

### New scripts: 
main_batch.py: This script can replace main.py when the user desires to process multiple trials. It includes a function that will incorporate the configuration YAML file and check that each trial is provided a folder of frames, a numpy dictionary of annotations, and unique names for both the masks and output video. It will then iterate through the list of trials, checking if other configuration parameters are provided a list of values or a single value and applying them to the trial index, and running the SAM2 fish_segmenter to propagate masks.  

create_video_batch.py: This script can replace the create_video.py when the user desires to create videos for multiple trials. Similar to main_batch.py, it includes a function that incorporates the configuration YAML file, checks that each trial is provided a folder of frames and unique names for both the masks and output videos, then iterating through the list of trials to create an output video for each trial.

### Restore previous GUI - tangential change
The recent updates to the GUI, which made out_fps a variable and easily-adjustable by the user in case a different temporal resolution for SAM2 is desired, incidentally resulted in significant computational costs and crashed Python when loading full videos (1-3GB). I restored the previous version of the GUI which is functional for large videos, and updated the README for how to edit that value within the script. 